### PR TITLE
Use _DEFAULT_SOURCE instead of _BSD_SOURCE, as _BSD_SOURCE is deprecated.

### DIFF
--- a/fuse/main.c
+++ b/fuse/main.c
@@ -17,7 +17,7 @@
  */
 
 #define _POSIX_C_SOURCE 200809L // for strdup and struct timespec
-#define _BSD_SOURCE             // for strdup on old systems
+#define _DEFAULT_SOURCE         // for strdup on old systems
 #define _GNU_SOURCE             // for getline on old systems
 
 #define FUSE_USE_VERSION 30

--- a/mfapi/apicalls/upload_patch.c
+++ b/mfapi/apicalls/upload_patch.c
@@ -18,7 +18,7 @@
  */
 
 #define _POSIX_C_SOURCE 200809L // for strdup
-#define _BSD_SOURCE             // for strdup on old systems
+#define _DEFAULT_SOURCE         // for strdup on old systems
 
 #include <jansson.h>
 #include <stdlib.h>

--- a/mfapi/apicalls/upload_simple.c
+++ b/mfapi/apicalls/upload_simple.c
@@ -18,7 +18,7 @@
  */
 
 #define _POSIX_C_SOURCE 200809L // for strdup
-#define _BSD_SOURCE             // for strdup on old systems
+#define _DEFAULT_SOURCE         // for strdup on old systems
 
 #include <jansson.h>
 #include <stdlib.h>

--- a/mfapi/apicalls/user_get_session_token.c
+++ b/mfapi/apicalls/user_get_session_token.c
@@ -18,7 +18,7 @@
  */
 
 #define _POSIX_C_SOURCE 200809L // for strdup
-#define _BSD_SOURCE             // for strdup on old systems
+#define _DEFAULT_SOURCE         // for strdup on old systems
 
 #include <jansson.h>
 #include <stdint.h>

--- a/mfapi/file.c
+++ b/mfapi/file.c
@@ -18,7 +18,7 @@
  */
 
 #define _POSIX_C_SOURCE 200809L // for strdup
-#define _BSD_SOURCE             // for strdup on old systems
+#define _DEFAULT_SOURCE         // for strdup on old systems
 
 #include <stdint.h>
 #include <stdio.h>

--- a/mfapi/mfconn.c
+++ b/mfapi/mfconn.c
@@ -18,7 +18,7 @@
  */
 
 #define _POSIX_C_SOURCE 200809L // for strdup
-#define _BSD_SOURCE             // for strdup on old systems
+#define _DEFAULT_SOURCE         // for strdup on old systems
 
 #include <openssl/md5.h>
 #include <openssl/sha.h>

--- a/mfapi/patch.c
+++ b/mfapi/patch.c
@@ -17,7 +17,7 @@
  */
 
 #define _POSIX_C_SOURCE 200809L // for strdup
-#define _BSD_SOURCE             // for strdup on old systems
+#define _DEFAULT_SOURCE         // for strdup on old systems
 
 #include <stdint.h>
 #include <openssl/sha.h>

--- a/mfshell/mfshell.c
+++ b/mfshell/mfshell.c
@@ -19,7 +19,7 @@
 
 #ifdef __linux
 #define _POSIX_C_SOURCE 200809L // for strdup and getline
-#define _BSD_SOURCE             // for strsep
+#define _DEFAULT_SOURCE         // for strsep
 #else
 #define _WITH_GETLINE           // on freebsd for getline
 #endif

--- a/utils/stringv.c
+++ b/utils/stringv.c
@@ -17,7 +17,7 @@
  */
 
 #define _POSIX_C_SOURCE 200809L // for strdup
-#define _BSD_SOURCE             // for strdup on old systems
+#define _DEFAULT_SOURCE         // for strdup on old systems
 
 #include <stdio.h>
 #include <stdlib.h>


### PR DESCRIPTION
`_BSD_SOURCE` is deprecated, which causes warnings on newer compilers; since warnings are treated as errors in the build infrastructure, this currently causes mediafire-fuse not to build at all.

My solution is to follow the suggestion the compiler gives, and swap `_BSD_SOURCE` for `_DEFAULT_SOURCE`.