### PR TITLE
Guard _XOPEN_SOURCE definitions, and cast strptime to (char *) explicitly.

### DIFF
--- a/mfapi/apicalls/file_get_info.c
+++ b/mfapi/apicalls/file_get_info.c
@@ -17,7 +17,10 @@
  *
  */
 
+#ifndef __OpenBSD__
 #define _XOPEN_SOURCE           // for strptime
+#endif
+
 #include <jansson.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -150,7 +153,7 @@ static int _decode_file_get_info(mfhttp * conn, void *data)
     obj = json_object_get(node, "created");
     if (obj != NULL) {
         memset(&tm, 0, sizeof(struct tm));
-        ret = strptime(json_string_value(obj), "%F %T", &tm);
+        ret = (char *) strptime(json_string_value(obj), "%F %T", &tm);
         if (ret[0] != '\0') {
             fprintf(stderr, "cannot parse time\n");
         } else {

--- a/mfapi/apicalls/folder_get_content.c
+++ b/mfapi/apicalls/folder_get_content.c
@@ -16,8 +16,10 @@
  * Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
  */
-
+#ifndef __OpenBSD__
 #define _XOPEN_SOURCE           // for strptime
+#endif
+
 #include <time.h>
 #include <jansson.h>
 #include <stdlib.h>
@@ -223,7 +225,7 @@ static int _decode_folder_get_content_folders(mfhttp * conn, void *user_ptr)
                 j_obj = json_object_get(data, "created");
                 if (j_obj != NULL) {
                     memset(&tm, 0, sizeof(struct tm));
-                    ret = strptime(json_string_value(j_obj), "%F %T", &tm);
+                    ret = (char *) strptime(json_string_value(j_obj), "%F %T", &tm);
                     if (ret[0] == '\0') {
                         folder_set_created(tmp_folder, mktime(&tm));
                     }

--- a/mfapi/apicalls/folder_get_info.c
+++ b/mfapi/apicalls/folder_get_info.c
@@ -16,8 +16,10 @@
  * Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
  */
-
+#ifndef __OpenBSD__
 #define _XOPEN_SOURCE           // for strptime
+#endif
+
 #include <jansson.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -156,7 +158,7 @@ static int _decode_folder_get_info(mfhttp * conn, void *data)
     created = json_object_get(node, "created");
     if (created != NULL) {
         memset(&tm, 0, sizeof(struct tm));
-        ret = strptime(json_string_value(created), "%F %T", &tm);
+        ret = (char *) strptime(json_string_value(created), "%F %T", &tm);
         if (ret[0] != '\0') {
             fprintf(stderr, "cannot parse time\n");
         } else {


### PR DESCRIPTION
The OpenBSD compiler toolchain throws warnings on `strptime` when `_XOPEN_SOURCE` is defined, and when strptime is not explicitly cast to `(char *)`.