### PR TITLE
enable -fms-extensions for all systems

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS 1)
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c99 -Wall -Werror")
 
 if (("${CMAKE_C_COMPILER_ID}" STREQUAL "Clang") OR (("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU") AND (CMAKE_C_COMPILER_VERSION VERSION_GREATER 4.0)))
-	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wextra")
+	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wextra -fms-extensions")
 else()
 	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fms-extensions")
 endif()


### PR DESCRIPTION
@josch , i had to add -fms-extensions to cmake in order to make centos 6.6 happy (which has gcc 4.4.7).  i'm not sure if this is the right approach.  if you know of a better means of addressing this, please do.  if not, please merge.