### PR TITLE
Zero byte support

### DIFF
--- a/fuse/filecache.c
+++ b/fuse/filecache.c
@@ -166,6 +166,51 @@ int filecache_upload_patch(const char *quickkey, uint64_t local_revision,
     return 0;
 }
 
+#define _POSIX_C_SOURCE 200809L
+int filecache_truncate_file(const char *quickkey, const char *key,
+			    uint64_t local_revision,
+			    uint64_t remote_revision,
+			    const char *filecache_path, mfconn * conn)
+{
+    char           *filepath;
+    int             retval;
+    int             fd;
+
+    /* truncate file on remote */
+    retval = mfconn_api_file_update(conn, key, NULL, NULL, true);
+    if (retval == -1) {
+	fprintf(stderr, "file update failed\n");
+	return -1;
+    }
+
+    /* truncate file on local */
+    filepath = strdup_printf("%s/%s_%d", filecache_path, quickkey,
+			      local_revision);
+    fd = open(filepath, O_TRUNC | O_WRONLY);
+    free(filepath);
+    close(fd);
+
+    filepath = strdup_printf("%s/%s_%d", filecache_path, quickkey,
+			      remote_revision);
+    fd = open(filepath, O_TRUNC | O_WRONLY);
+    free(filepath);
+    close(fd);
+
+    filepath = strdup_printf("%s/%s_%d_new", filecache_path, quickkey,
+			      local_revision);
+    fd = open(filepath, O_TRUNC | O_WRONLY);
+    free(filepath);
+    close(fd);
+
+    filepath = strdup_printf("%s/%s_%d_new", filecache_path, quickkey,
+			      remote_revision);
+    fd = open(filepath, O_TRUNC | O_WRONLY);
+    free(filepath);
+    close(fd);
+
+    return 0;
+}
+
 int filecache_open_file(const char *quickkey, uint64_t local_revision,
                         uint64_t remote_revision, uint64_t fsize,
                         const unsigned char *fhash,

--- a/fuse/filecache.c
+++ b/fuse/filecache.c
@@ -109,6 +109,7 @@ int filecache_upload_patch(const char *quickkey, uint64_t local_revision,
 
     source_hash = binary2hex(hash, SHA256_DIGEST_LENGTH);
 
+    target_size = -1;
     retval = calc_sha256(target_fh, hash, &target_size);
 
     if (retval != 0) {

--- a/fuse/filecache.h
+++ b/fuse/filecache.h
@@ -26,6 +26,11 @@ int             filecache_open_file(const char *quickkey,
                                     const char *filecache, mfconn * conn,
                                     mode_t mode, bool update);
 
+int             filecache_truncate_file(const char *quickkey, const char *key,
+                                    uint64_t local_revision,
+                                    uint64_t remote_revision,
+                                    const char *filecache_path, mfconn * conn);
+
 int             filecache_upload_patch(const char *quickkey,
                                        uint64_t local_revision,
                                        const char *filecache, mfconn * conn);

--- a/fuse/filecache.h
+++ b/fuse/filecache.h
@@ -31,6 +31,12 @@ int             filecache_truncate_file(const char *quickkey, const char *key,
                                     uint64_t remote_revision,
                                     const char *filecache_path, mfconn * conn);
 
+int             filecache_get_new_and_old_sizes(const char *quickkey,
+						uint64_t local_revision,
+						const char *filecache_path,
+						off_t *newsize,
+						off_t *oldsize);
+
 int             filecache_upload_patch(const char *quickkey,
                                        uint64_t local_revision,
                                        const char *filecache, mfconn * conn);

--- a/fuse/filecache.h
+++ b/fuse/filecache.h
@@ -31,14 +31,10 @@ int             filecache_truncate_file(const char *quickkey, const char *key,
                                     uint64_t remote_revision,
                                     const char *filecache_path, mfconn * conn);
 
-int             filecache_get_new_and_old_sizes(const char *quickkey,
-						uint64_t local_revision,
-						const char *filecache_path,
-						off_t *newsize,
-						off_t *oldsize);
-
 int             filecache_upload_patch(const char *quickkey,
                                        uint64_t local_revision,
-                                       const char *filecache, mfconn * conn);
+                                       const char *filecache, mfconn * conn,
+				       const char *filename,
+				       const char *folder_key);
 
 #endif

--- a/fuse/hashtbl.h
+++ b/fuse/hashtbl.h
@@ -80,6 +80,11 @@ int             folder_tree_open_file(folder_tree * tree, mfconn * conn,
                                       bool update);
 int             folder_tree_truncate_file(folder_tree * tree, mfconn * conn,
 					  const char *path);
+int             folder_tree_get_new_and_old_sizes(folder_tree * tree,
+						  mfconn * conn,
+						  const char * path,
+						  off_t * newsize,
+						  off_t * oldsize);
 int             folder_tree_tmp_open(folder_tree * tree);
 
 int             folder_tree_upload_patch(folder_tree * tree, mfconn * conn,

--- a/fuse/hashtbl.h
+++ b/fuse/hashtbl.h
@@ -78,7 +78,8 @@ bool            folder_tree_path_is_file(folder_tree * tree, mfconn * conn,
 int             folder_tree_open_file(folder_tree * tree, mfconn * conn,
                                       const char *path, mode_t mode,
                                       bool update);
-
+int             folder_tree_truncate_file(folder_tree * tree, mfconn * conn,
+					  const char *path);
 int             folder_tree_tmp_open(folder_tree * tree);
 
 int             folder_tree_upload_patch(folder_tree * tree, mfconn * conn,

--- a/fuse/hashtbl.h
+++ b/fuse/hashtbl.h
@@ -80,11 +80,6 @@ int             folder_tree_open_file(folder_tree * tree, mfconn * conn,
                                       bool update);
 int             folder_tree_truncate_file(folder_tree * tree, mfconn * conn,
 					  const char *path);
-int             folder_tree_get_new_and_old_sizes(folder_tree * tree,
-						  mfconn * conn,
-						  const char * path,
-						  off_t * newsize,
-						  off_t * oldsize);
 int             folder_tree_tmp_open(folder_tree * tree);
 
 int             folder_tree_upload_patch(folder_tree * tree, mfconn * conn,

--- a/fuse/operations.c
+++ b/fuse/operations.c
@@ -109,6 +109,7 @@ struct mediafirefs_openfile {
 
 int mediafirefs_getattr(const char *path, struct stat *stbuf)
 {
+    printf("FUNCTION: getattr. path: %s\n", path);
     /*
      * since getattr is called before every other call (except for getattr,
      * read and write) wee only call folder_tree_update in the getattr call
@@ -150,6 +151,7 @@ int mediafirefs_getattr(const char *path, struct stat *stbuf)
 int mediafirefs_readdir(const char *path, void *buf, fuse_fill_dir_t filldir,
                         off_t offset, struct fuse_file_info *info)
 {
+    printf("FUNCTION: readdir. path: %s\n", path);
     (void)offset;
     (void)info;
     struct mediafirefs_context_private *ctx;
@@ -166,6 +168,7 @@ int mediafirefs_readdir(const char *path, void *buf, fuse_fill_dir_t filldir,
 
 void mediafirefs_destroy(void *user_ptr)
 {
+    printf("FUNCTION: destroy\n");
     FILE           *fd;
     struct mediafirefs_context_private *ctx;
 
@@ -196,6 +199,8 @@ void mediafirefs_destroy(void *user_ptr)
 
 int mediafirefs_mkdir(const char *path, mode_t mode)
 {
+    printf("FUNCTION: mkdir. path: %s\n", path);
+
     (void)mode;
 
     char           *dirname;
@@ -263,6 +268,7 @@ int mediafirefs_mkdir(const char *path, mode_t mode)
 
 int mediafirefs_rmdir(const char *path)
 {
+    printf("FUNCTION: rmdir. path: %s\n", path);
     const char     *key;
     int             retval;
     struct mediafirefs_context_private *ctx;
@@ -304,6 +310,7 @@ int mediafirefs_rmdir(const char *path)
 
 int mediafirefs_unlink(const char *path)
 {
+    printf("FUNCTION: unlink. path: %s\n", path);
     const char     *key;
     int             retval;
     struct mediafirefs_context_private *ctx;
@@ -365,6 +372,7 @@ int mediafirefs_unlink(const char *path)
  */
 int mediafirefs_open(const char *path, struct fuse_file_info *file_info)
 {
+    printf("FUNCTION: open. path: %s\n", path);
     int             fd;
     bool            is_open;
     struct mediafirefs_openfile *openfile;
@@ -436,6 +444,8 @@ int mediafirefs_open(const char *path, struct fuse_file_info *file_info)
 int mediafirefs_create(const char *path, mode_t mode,
                        struct fuse_file_info *file_info)
 {
+    printf("FUNCTION: create. path: %s\n", path);
+
     (void)mode;
 
     int             fd;
@@ -471,6 +481,8 @@ int mediafirefs_create(const char *path, mode_t mode,
 int mediafirefs_read(const char *path, char *buf, size_t size, off_t offset,
                      struct fuse_file_info *file_info)
 {
+    printf("FUNCTION: read. path: %s\n", path);
+
     (void)path;
     ssize_t         retval;
     struct mediafirefs_context_private *ctx;
@@ -490,6 +502,8 @@ int mediafirefs_read(const char *path, char *buf, size_t size, off_t offset,
 int mediafirefs_write(const char *path, const char *buf, size_t size,
                       off_t offset, struct fuse_file_info *file_info)
 {
+    printf("FUNCTION: write. path: %s\n", path);
+
     (void)path;
     ssize_t         retval;
     struct mediafirefs_context_private *ctx;
@@ -516,6 +530,8 @@ int mediafirefs_write(const char *path, const char *buf, size_t size,
  */
 int mediafirefs_release(const char *path, struct fuse_file_info *file_info)
 {
+    printf("FUNCTION: release. path: %s\n", path);
+
     (void)path;
 
     FILE           *fh;
@@ -537,7 +553,7 @@ int mediafirefs_release(const char *path, struct fuse_file_info *file_info)
 
     // zero out check result to prevent spurious results later
     memset(&check_result,0,sizeof(check_result));
-
+    
     pthread_mutex_lock(&(ctx->mutex));
 
     openfile = (struct mediafirefs_openfile *)(uintptr_t) file_info->fh;
@@ -700,6 +716,8 @@ int mediafirefs_release(const char *path, struct fuse_file_info *file_info)
 
 int mediafirefs_readlink(const char *path, char *buf, size_t bufsize)
 {
+    printf("FUNCTION: readlink. path: %s\n", path);
+
     (void)path;
     (void)buf;
     (void)bufsize;
@@ -718,6 +736,8 @@ int mediafirefs_readlink(const char *path, char *buf, size_t bufsize)
 
 int mediafirefs_mknod(const char *path, mode_t mode, dev_t dev)
 {
+    printf("FUNCTION: mknod. path: %s\n", path);
+
     (void)path;
     (void)mode;
     (void)dev;
@@ -736,6 +756,8 @@ int mediafirefs_mknod(const char *path, mode_t mode, dev_t dev)
 
 int mediafirefs_symlink(const char *target, const char *linkpath)
 {
+    printf("FUNCTION: symlink. target: %s, linkpath: %s\n", target, linkpath);
+
     (void)target;
     (void)linkpath;
     struct mediafirefs_context_private *ctx;
@@ -753,6 +775,8 @@ int mediafirefs_symlink(const char *target, const char *linkpath)
 
 int mediafirefs_rename(const char *oldpath, const char *newpath)
 {
+    printf("FUNCTION: rename. oldpath: %s, newpath %s\n", oldpath, newpath);
+
     char           *temp1;
     char           *temp2;
     char           *olddir;
@@ -851,6 +875,8 @@ int mediafirefs_rename(const char *oldpath, const char *newpath)
 
 int mediafirefs_link(const char *target, const char *linkpath)
 {
+    printf("FUNCTION: link. target: %s, linkpath %s\n", target, linkpath);
+
     (void)target;
     (void)linkpath;
     struct mediafirefs_context_private *ctx;
@@ -868,6 +894,7 @@ int mediafirefs_link(const char *target, const char *linkpath)
 
 int mediafirefs_chmod(const char *path, mode_t mode)
 {
+    printf("FUNCTION: chmod. path: %s\n", path);
     (void)path;
     (void)mode;
     struct mediafirefs_context_private *ctx;
@@ -885,6 +912,8 @@ int mediafirefs_chmod(const char *path, mode_t mode)
 
 int mediafirefs_chown(const char *path, uid_t uid, gid_t gid)
 {
+    printf("FUNCTION: chown. path: %s\n", path);
+
     (void)path;
     (void)uid;
     (void)gid;
@@ -903,6 +932,8 @@ int mediafirefs_chown(const char *path, uid_t uid, gid_t gid)
 
 int mediafirefs_truncate(const char *path, off_t length)
 {
+    printf("FUNCTION: truncate. path: %s, length: %zd\n", path, length);
+
     // FIXME: implement this
     (void)path;
     (void)length;
@@ -921,6 +952,8 @@ int mediafirefs_truncate(const char *path, off_t length)
 
 int mediafirefs_statfs(const char *path, struct statvfs *buf)
 {
+    printf("FUNCTION: statfs. path: %s\n", path);
+
     // TODO:    add mfuser to ctx and store it accross the system.
     //          instantiating it every time on a per-instance is not ideal.
 
@@ -985,6 +1018,8 @@ int mediafirefs_statfs(const char *path, struct statvfs *buf)
 
 int mediafirefs_flush(const char *path, struct fuse_file_info *file_info)
 {
+    printf("FUNCTION: flush. path: %s\n", path);
+
     (void)path;
     (void)file_info;
     struct mediafirefs_context_private *ctx;
@@ -1003,6 +1038,8 @@ int mediafirefs_flush(const char *path, struct fuse_file_info *file_info)
 int mediafirefs_fsync(const char *path, int datasync,
                       struct fuse_file_info *file_info)
 {
+    printf("FUNCTION: fsync. path: %s\n", path);
+
     (void)path;
     (void)datasync;
     (void)file_info;
@@ -1022,6 +1059,8 @@ int mediafirefs_fsync(const char *path, int datasync,
 int mediafirefs_setxattr(const char *path, const char *name,
                          const char *value, size_t size, int flags)
 {
+    printf("FUNCTION: setxattr. path: %s\n", path);
+
     (void)path;
     (void)name;
     (void)value;
@@ -1043,6 +1082,8 @@ int mediafirefs_setxattr(const char *path, const char *name,
 int mediafirefs_getxattr(const char *path, const char *name, char *value,
                          size_t size)
 {
+    printf("FUNCTION: getxattr. path: %s\n", path);
+
     (void)path;
     (void)name;
     (void)value;
@@ -1062,6 +1103,8 @@ int mediafirefs_getxattr(const char *path, const char *name, char *value,
 
 int mediafirefs_listxattr(const char *path, char *list, size_t size)
 {
+    printf("FUNCTION: listxattr. path: %s\n", path);
+
     (void)path;
     (void)list;
     (void)size;
@@ -1080,6 +1123,8 @@ int mediafirefs_listxattr(const char *path, char *list, size_t size)
 
 int mediafirefs_removexattr(const char *path, const char *list)
 {
+    printf("FUNCTION: removexattr. path: %s\n", path);
+
     (void)path;
     (void)list;
     struct mediafirefs_context_private *ctx;
@@ -1097,6 +1142,8 @@ int mediafirefs_removexattr(const char *path, const char *list)
 
 int mediafirefs_opendir(const char *path, struct fuse_file_info *file_info)
 {
+    printf("FUNCTION: opendir. path: %s\n", path);
+
     (void)path;
     (void)file_info;
     struct mediafirefs_context_private *ctx;
@@ -1114,6 +1161,8 @@ int mediafirefs_opendir(const char *path, struct fuse_file_info *file_info)
 
 int mediafirefs_releasedir(const char *path, struct fuse_file_info *file_info)
 {
+    printf("FUNCTION: releasedir. path: %s\n", path);
+
     (void)path;
     (void)file_info;
     struct mediafirefs_context_private *ctx;
@@ -1132,6 +1181,8 @@ int mediafirefs_releasedir(const char *path, struct fuse_file_info *file_info)
 int mediafirefs_fsyncdir(const char *path, int datasync,
                          struct fuse_file_info *file_info)
 {
+    printf("FUNCTION: fsyncdir. path: %s\n", path);
+
     (void)path;
     (void)datasync;
     (void)file_info;
@@ -1158,6 +1209,8 @@ void* mediafirefs_init(struct fuse_conn_info *conn)
 
 int mediafirefs_access(const char *path, int mode)
 {
+    printf("FUNCTION: access. path: %s\n", path);
+
     (void)path;
     (void)mode;
     struct mediafirefs_context_private *ctx;
@@ -1175,6 +1228,8 @@ int mediafirefs_access(const char *path, int mode)
 
 int mediafirefs_utimens(const char *path, const struct timespec tv[2])
 {
+    printf("FUNCTION: utimens. path: %s\n", path);
+
     time_t          since_epoch;
     struct tm       local_time;
     static int      b_tzset = 0;        // has tzset() been called

--- a/fuse/operations.c
+++ b/fuse/operations.c
@@ -534,20 +534,9 @@ int mediafirefs_release(const char *path, struct fuse_file_info *file_info)
 
     (void)path;
 
-//    FILE           *fh;
-//    char           *file_name;
-//    char           *dir_name;
-//    const char     *folder_key;
-//    char           *upload_key;
-//    char           *temp1;
-//    char           *temp2;
-//    int             retval;
     struct mediafirefs_context_private *ctx;
     struct mediafirefs_openfile *openfile;
     struct mfconn_upload_check_result check_result;
-//    unsigned char   bhash[SHA256_DIGEST_LENGTH];
-//    char           *hash;
-//    uint64_t        size;
 
     ctx = fuse_get_context()->private_data;
 
@@ -586,133 +575,11 @@ int mediafirefs_release(const char *path, struct fuse_file_info *file_info)
         exit(1);
     }
 
-    // if the file only exists locally, an initial upload has to be done
-
-/*
-    if (openfile->is_local) {
-        // pass a copy because dirname and basename may modify their argument
-        temp1 = strdup(openfile->path);
-        file_name = basename(temp1);
-        temp2 = strdup(openfile->path);
-        dir_name = dirname(temp2);
-
-        fh = fdopen(openfile->fd, "r");
-        rewind(fh);
-
-        folder_key = folder_tree_path_get_key(ctx->tree, ctx->conn, dir_name);
-
-	size = -1;
-        retval = calc_sha256(fh, bhash, &size);
-        rewind(fh);
-
-        if (retval != 0) {
-            fprintf(stderr, "failed to calculate hash\n");
-            fclose(fh);
-            free(temp1);
-            free(temp2);
-            free(openfile->path);
-            free(openfile);
-            pthread_mutex_unlock(&(ctx->mutex));
-            return -EACCES;
-        }
-
-        hash = binary2hex(bhash, SHA256_DIGEST_LENGTH);
-
-        retval = mfconn_api_upload_check(ctx->conn, file_name, hash, size,
-                                         folder_key, &check_result);
-
-        if (retval != 0) {
-            fclose(fh);
-            free(temp1);
-            free(temp2);
-            free(openfile->path);
-            free(openfile);
-            free(hash);
-            fprintf(stderr, "mfconn_api_upload_check failed\n");
-            fprintf(stderr, "file_name: %s\n",file_name);
-            fprintf(stderr, "hash: %s\n",hash);
-            fprintf(stderr, "size: %jd\n",size);
-            fprintf(stderr, "folder_key: %s\n",folder_key);
-            pthread_mutex_unlock(&(ctx->mutex));
-            return -EACCES;
-        }
-
-        if (check_result.hash_exists) {
-            // hash exists, so use upload/instant
-
-            retval = mfconn_api_upload_instant(ctx->conn, NULL,
-                                               file_name, hash, size,
-                                               folder_key);
-
-            fclose(fh);
-            free(temp1);
-            free(temp2);
-            free(openfile->path);
-            free(openfile);
-            free(hash);
-
-            if (retval != 0) {
-                fprintf(stderr, "mfconn_api_upload_instant failed\n");
-                pthread_mutex_unlock(&(ctx->mutex));
-                return -EACCES;
-            }
-        } else {
-            // hash does not exist, so do full upload
-            upload_key = NULL;
-            retval = mfconn_api_upload_simple(ctx->conn, folder_key,
-                                              fh, file_name, &upload_key);
-
-            fclose(fh);
-            free(temp1);
-            free(temp2);
-            free(openfile->path);
-            free(openfile);
-            free(hash);
-
-            if (retval != 0 || upload_key == NULL) {
-
-                fprintf(stderr, "mfconn_api_upload_simple failed\n");
-                fprintf(stderr, "file_name: %s\n",file_name);
-                fprintf(stderr, "hash: %s\n",hash);
-                fprintf(stderr, "size: %jd\n",size);
-                fprintf(stderr, "folder_key: %s\n",folder_key);
-
-                pthread_mutex_unlock(&(ctx->mutex));
-                return -EACCES;
-            }
-            // poll for completion
-            retval = mfconn_upload_poll_for_completion(ctx->conn, upload_key);
-            free(upload_key);
-
-            if (retval != 0) {
-                fprintf(stderr, "mfconn_upload_poll_for_completion failed\n");
-                pthread_mutex_unlock(&(ctx->mutex));
-                return -1;
-            }
-        }
-
-        folder_tree_update(ctx->tree, ctx->conn, true);
-        pthread_mutex_unlock(&(ctx->mutex));
-        return 0;
-    }
-*/
-    // the file was not opened readonly and also existed on the remote
-    // thus, we have to check whether any changes were made and if yes, upload
-    // a patch
-
     close(openfile->fd);
 
-//    retval = folder_tree_upload_patch(ctx->tree, ctx->conn, openfile->path);
     free(openfile->path);
     free(openfile);
 
-/*
-    if (retval != 0) {
-        fprintf(stderr, "folder_tree_upload_patch failed\n");
-        pthread_mutex_unlock(&(ctx->mutex));
-        return -EACCES;
-    }
-*/
     folder_tree_update(ctx->tree, ctx->conn, true);
 
     pthread_mutex_unlock(&(ctx->mutex));

--- a/fuse/operations.c
+++ b/fuse/operations.c
@@ -930,7 +930,7 @@ int mediafirefs_statfs(const char *path, struct statvfs *buf)
 int mediafirefs_flush(const char *path, struct fuse_file_info *file_info)
 {
 //    printf("FUNCTION: flush. path: %s\n", path);
-
+    (void) path;
     FILE           *fh;
     char           *file_name;
     char           *dir_name;

--- a/fuse/operations.c
+++ b/fuse/operations.c
@@ -109,7 +109,7 @@ struct mediafirefs_openfile {
 
 int mediafirefs_getattr(const char *path, struct stat *stbuf)
 {
-//    printf("FUNCTION: getattr. path: %s\n", path);
+    printf("FUNCTION: getattr. path: %s\n", path);
     /*
      * since getattr is called before every other call (except for getattr,
      * read and write) wee only call folder_tree_update in the getattr call
@@ -151,7 +151,7 @@ int mediafirefs_getattr(const char *path, struct stat *stbuf)
 int mediafirefs_readdir(const char *path, void *buf, fuse_fill_dir_t filldir,
                         off_t offset, struct fuse_file_info *info)
 {
-//    printf("FUNCTION: readdir. path: %s\n", path);
+    printf("FUNCTION: readdir. path: %s\n", path);
     (void)offset;
     (void)info;
     struct mediafirefs_context_private *ctx;
@@ -168,7 +168,7 @@ int mediafirefs_readdir(const char *path, void *buf, fuse_fill_dir_t filldir,
 
 void mediafirefs_destroy(void *user_ptr)
 {
-//    printf("FUNCTION: destroy\n");
+    printf("FUNCTION: destroy\n");
     FILE           *fd;
     struct mediafirefs_context_private *ctx;
 
@@ -199,7 +199,7 @@ void mediafirefs_destroy(void *user_ptr)
 
 int mediafirefs_mkdir(const char *path, mode_t mode)
 {
-//    printf("FUNCTION: mkdir. path: %s\n", path);
+    printf("FUNCTION: mkdir. path: %s\n", path);
 
     (void)mode;
 
@@ -268,7 +268,7 @@ int mediafirefs_mkdir(const char *path, mode_t mode)
 
 int mediafirefs_rmdir(const char *path)
 {
-//    printf("FUNCTION: rmdir. path: %s\n", path);
+    printf("FUNCTION: rmdir. path: %s\n", path);
     const char     *key;
     int             retval;
     struct mediafirefs_context_private *ctx;
@@ -310,7 +310,7 @@ int mediafirefs_rmdir(const char *path)
 
 int mediafirefs_unlink(const char *path)
 {
-//    printf("FUNCTION: unlink. path: %s\n", path);
+    printf("FUNCTION: unlink. path: %s\n", path);
     const char     *key;
     int             retval;
     struct mediafirefs_context_private *ctx;
@@ -372,7 +372,7 @@ int mediafirefs_unlink(const char *path)
  */
 int mediafirefs_open(const char *path, struct fuse_file_info *file_info)
 {
-//    printf("FUNCTION: open. path: %s\n", path);
+    printf("FUNCTION: open. path: %s\n", path);
     int             fd;
     bool            is_open;
     struct mediafirefs_openfile *openfile;
@@ -444,7 +444,7 @@ int mediafirefs_open(const char *path, struct fuse_file_info *file_info)
 int mediafirefs_create(const char *path, mode_t mode,
                        struct fuse_file_info *file_info)
 {
-//    printf("FUNCTION: create. path: %s\n", path);
+    printf("FUNCTION: create. path: %s\n", path);
 
     (void)mode;
 
@@ -481,7 +481,7 @@ int mediafirefs_create(const char *path, mode_t mode,
 int mediafirefs_read(const char *path, char *buf, size_t size, off_t offset,
                      struct fuse_file_info *file_info)
 {
-//    printf("FUNCTION: read. path: %s\n", path);
+    printf("FUNCTION: read. path: %s\n", path);
 
     (void)path;
     ssize_t         retval;
@@ -502,7 +502,7 @@ int mediafirefs_read(const char *path, char *buf, size_t size, off_t offset,
 int mediafirefs_write(const char *path, const char *buf, size_t size,
                       off_t offset, struct fuse_file_info *file_info)
 {
-//    printf("FUNCTION: write. path: %s\n", path);
+    printf("FUNCTION: write. path: %s\n", path);
 
     (void)path;
     ssize_t         retval;
@@ -530,7 +530,7 @@ int mediafirefs_write(const char *path, const char *buf, size_t size,
  */
 int mediafirefs_release(const char *path, struct fuse_file_info *file_info)
 {
-//    printf("FUNCTION: release. path: %s\n", path);
+    printf("FUNCTION: release. path: %s\n", path);
 
     (void)path;
 
@@ -589,7 +589,7 @@ int mediafirefs_release(const char *path, struct fuse_file_info *file_info)
 
 int mediafirefs_readlink(const char *path, char *buf, size_t bufsize)
 {
-//    printf("FUNCTION: readlink. path: %s\n", path);
+    printf("FUNCTION: readlink. path: %s\n", path);
 
     (void)path;
     (void)buf;
@@ -609,7 +609,7 @@ int mediafirefs_readlink(const char *path, char *buf, size_t bufsize)
 
 int mediafirefs_mknod(const char *path, mode_t mode, dev_t dev)
 {
-//    printf("FUNCTION: mknod. path: %s\n", path);
+    printf("FUNCTION: mknod. path: %s\n", path);
 
     (void)path;
     (void)mode;
@@ -629,7 +629,7 @@ int mediafirefs_mknod(const char *path, mode_t mode, dev_t dev)
 
 int mediafirefs_symlink(const char *target, const char *linkpath)
 {
-//    printf("FUNCTION: symlink. target: %s, linkpath: %s\n", target, linkpath);
+    printf("FUNCTION: symlink. target: %s, linkpath: %s\n", target, linkpath);
 
     (void)target;
     (void)linkpath;
@@ -648,7 +648,7 @@ int mediafirefs_symlink(const char *target, const char *linkpath)
 
 int mediafirefs_rename(const char *oldpath, const char *newpath)
 {
-//    printf("FUNCTION: rename. oldpath: %s, newpath %s\n", oldpath, newpath);
+    printf("FUNCTION: rename. oldpath: %s, newpath %s\n", oldpath, newpath);
 
     char           *temp1;
     char           *temp2;
@@ -748,7 +748,7 @@ int mediafirefs_rename(const char *oldpath, const char *newpath)
 
 int mediafirefs_link(const char *target, const char *linkpath)
 {
-//    printf("FUNCTION: link. target: %s, linkpath %s\n", target, linkpath);
+    printf("FUNCTION: link. target: %s, linkpath %s\n", target, linkpath);
 
     (void)target;
     (void)linkpath;
@@ -767,7 +767,7 @@ int mediafirefs_link(const char *target, const char *linkpath)
 
 int mediafirefs_chmod(const char *path, mode_t mode)
 {
-//    printf("FUNCTION: chmod. path: %s\n", path);
+    printf("FUNCTION: chmod. path: %s\n", path);
     (void)path;
     (void)mode;
     struct mediafirefs_context_private *ctx;
@@ -785,7 +785,7 @@ int mediafirefs_chmod(const char *path, mode_t mode)
 
 int mediafirefs_chown(const char *path, uid_t uid, gid_t gid)
 {
-//    printf("FUNCTION: chown. path: %s\n", path);
+    printf("FUNCTION: chown. path: %s\n", path);
 
     (void)path;
     (void)uid;
@@ -805,7 +805,7 @@ int mediafirefs_chown(const char *path, uid_t uid, gid_t gid)
 
 int mediafirefs_truncate(const char *path, off_t length)
 {
-//    printf("FUNCTION: truncate. path: %s, length: %zd\n", path, length);
+    printf("FUNCTION: truncate. path: %s, length: %zd\n", path, length);
 
     bool            is_file = 0;
     const char     *key = NULL;
@@ -863,7 +863,7 @@ int mediafirefs_truncate(const char *path, off_t length)
 
 int mediafirefs_statfs(const char *path, struct statvfs *buf)
 {
-//    printf("FUNCTION: statfs. path: %s\n", path);
+    printf("FUNCTION: statfs. path: %s\n", path);
 
     // TODO:    add mfuser to ctx and store it accross the system.
     //          instantiating it every time on a per-instance is not ideal.
@@ -929,7 +929,7 @@ int mediafirefs_statfs(const char *path, struct statvfs *buf)
 
 int mediafirefs_flush(const char *path, struct fuse_file_info *file_info)
 {
-//    printf("FUNCTION: flush. path: %s\n", path);
+    printf("FUNCTION: flush. path: %s\n", path);
     (void) path;
     FILE           *fh;
     char           *file_name;
@@ -1107,7 +1107,7 @@ int mediafirefs_flush(const char *path, struct fuse_file_info *file_info)
 int mediafirefs_fsync(const char *path, int datasync,
                       struct fuse_file_info *file_info)
 {
-//    printf("FUNCTION: fsync. path: %s\n", path);
+    printf("FUNCTION: fsync. path: %s\n", path);
 
     (void)path;
     (void)datasync;
@@ -1128,7 +1128,7 @@ int mediafirefs_fsync(const char *path, int datasync,
 int mediafirefs_setxattr(const char *path, const char *name,
                          const char *value, size_t size, int flags)
 {
-//    printf("FUNCTION: setxattr. path: %s\n", path);
+    printf("FUNCTION: setxattr. path: %s\n", path);
 
     (void)path;
     (void)name;
@@ -1151,7 +1151,7 @@ int mediafirefs_setxattr(const char *path, const char *name,
 int mediafirefs_getxattr(const char *path, const char *name, char *value,
                          size_t size)
 {
-//    printf("FUNCTION: getxattr. path: %s\n", path);
+    printf("FUNCTION: getxattr. path: %s\n", path);
 
     (void)path;
     (void)name;
@@ -1172,7 +1172,7 @@ int mediafirefs_getxattr(const char *path, const char *name, char *value,
 
 int mediafirefs_listxattr(const char *path, char *list, size_t size)
 {
-//    printf("FUNCTION: listxattr. path: %s\n", path);
+    printf("FUNCTION: listxattr. path: %s\n", path);
 
     (void)path;
     (void)list;
@@ -1192,7 +1192,7 @@ int mediafirefs_listxattr(const char *path, char *list, size_t size)
 
 int mediafirefs_removexattr(const char *path, const char *list)
 {
-//    printf("FUNCTION: removexattr. path: %s\n", path);
+    printf("FUNCTION: removexattr. path: %s\n", path);
 
     (void)path;
     (void)list;
@@ -1211,7 +1211,7 @@ int mediafirefs_removexattr(const char *path, const char *list)
 
 int mediafirefs_opendir(const char *path, struct fuse_file_info *file_info)
 {
-//    printf("FUNCTION: opendir. path: %s\n", path);
+    printf("FUNCTION: opendir. path: %s\n", path);
 
     (void)path;
     (void)file_info;
@@ -1230,7 +1230,7 @@ int mediafirefs_opendir(const char *path, struct fuse_file_info *file_info)
 
 int mediafirefs_releasedir(const char *path, struct fuse_file_info *file_info)
 {
-//    printf("FUNCTION: releasedir. path: %s\n", path);
+    printf("FUNCTION: releasedir. path: %s\n", path);
 
     (void)path;
     (void)file_info;
@@ -1250,7 +1250,7 @@ int mediafirefs_releasedir(const char *path, struct fuse_file_info *file_info)
 int mediafirefs_fsyncdir(const char *path, int datasync,
                          struct fuse_file_info *file_info)
 {
-//    printf("FUNCTION: fsyncdir. path: %s\n", path);
+    printf("FUNCTION: fsyncdir. path: %s\n", path);
 
     (void)path;
     (void)datasync;
@@ -1278,7 +1278,7 @@ void* mediafirefs_init(struct fuse_conn_info *conn)
 
 int mediafirefs_access(const char *path, int mode)
 {
-//    printf("FUNCTION: access. path: %s\n", path);
+    printf("FUNCTION: access. path: %s\n", path);
 
     (void)path;
     (void)mode;
@@ -1297,7 +1297,7 @@ int mediafirefs_access(const char *path, int mode)
 
 int mediafirefs_utimens(const char *path, const struct timespec tv[2])
 {
-//    printf("FUNCTION: utimens. path: %s\n", path);
+    printf("FUNCTION: utimens. path: %s\n", path);
 
     time_t          since_epoch;
     struct tm       local_time;

--- a/fuse/operations.c
+++ b/fuse/operations.c
@@ -598,6 +598,7 @@ int mediafirefs_release(const char *path, struct fuse_file_info *file_info)
 
         folder_key = folder_tree_path_get_key(ctx->tree, ctx->conn, dir_name);
 
+	size = -1;
         retval = calc_sha256(fh, bhash, &size);
         rewind(fh);
 

--- a/fuse/operations.c
+++ b/fuse/operations.c
@@ -109,7 +109,7 @@ struct mediafirefs_openfile {
 
 int mediafirefs_getattr(const char *path, struct stat *stbuf)
 {
-    printf("FUNCTION: getattr. path: %s\n", path);
+//    printf("FUNCTION: getattr. path: %s\n", path);
     /*
      * since getattr is called before every other call (except for getattr,
      * read and write) wee only call folder_tree_update in the getattr call
@@ -151,7 +151,7 @@ int mediafirefs_getattr(const char *path, struct stat *stbuf)
 int mediafirefs_readdir(const char *path, void *buf, fuse_fill_dir_t filldir,
                         off_t offset, struct fuse_file_info *info)
 {
-    printf("FUNCTION: readdir. path: %s\n", path);
+//    printf("FUNCTION: readdir. path: %s\n", path);
     (void)offset;
     (void)info;
     struct mediafirefs_context_private *ctx;
@@ -168,7 +168,7 @@ int mediafirefs_readdir(const char *path, void *buf, fuse_fill_dir_t filldir,
 
 void mediafirefs_destroy(void *user_ptr)
 {
-    printf("FUNCTION: destroy\n");
+//    printf("FUNCTION: destroy\n");
     FILE           *fd;
     struct mediafirefs_context_private *ctx;
 
@@ -199,7 +199,7 @@ void mediafirefs_destroy(void *user_ptr)
 
 int mediafirefs_mkdir(const char *path, mode_t mode)
 {
-    printf("FUNCTION: mkdir. path: %s\n", path);
+//    printf("FUNCTION: mkdir. path: %s\n", path);
 
     (void)mode;
 
@@ -268,7 +268,7 @@ int mediafirefs_mkdir(const char *path, mode_t mode)
 
 int mediafirefs_rmdir(const char *path)
 {
-    printf("FUNCTION: rmdir. path: %s\n", path);
+//    printf("FUNCTION: rmdir. path: %s\n", path);
     const char     *key;
     int             retval;
     struct mediafirefs_context_private *ctx;
@@ -310,7 +310,7 @@ int mediafirefs_rmdir(const char *path)
 
 int mediafirefs_unlink(const char *path)
 {
-    printf("FUNCTION: unlink. path: %s\n", path);
+//    printf("FUNCTION: unlink. path: %s\n", path);
     const char     *key;
     int             retval;
     struct mediafirefs_context_private *ctx;
@@ -372,7 +372,7 @@ int mediafirefs_unlink(const char *path)
  */
 int mediafirefs_open(const char *path, struct fuse_file_info *file_info)
 {
-    printf("FUNCTION: open. path: %s\n", path);
+//    printf("FUNCTION: open. path: %s\n", path);
     int             fd;
     bool            is_open;
     struct mediafirefs_openfile *openfile;
@@ -444,7 +444,7 @@ int mediafirefs_open(const char *path, struct fuse_file_info *file_info)
 int mediafirefs_create(const char *path, mode_t mode,
                        struct fuse_file_info *file_info)
 {
-    printf("FUNCTION: create. path: %s\n", path);
+//    printf("FUNCTION: create. path: %s\n", path);
 
     (void)mode;
 
@@ -481,7 +481,7 @@ int mediafirefs_create(const char *path, mode_t mode,
 int mediafirefs_read(const char *path, char *buf, size_t size, off_t offset,
                      struct fuse_file_info *file_info)
 {
-    printf("FUNCTION: read. path: %s\n", path);
+//    printf("FUNCTION: read. path: %s\n", path);
 
     (void)path;
     ssize_t         retval;
@@ -502,7 +502,7 @@ int mediafirefs_read(const char *path, char *buf, size_t size, off_t offset,
 int mediafirefs_write(const char *path, const char *buf, size_t size,
                       off_t offset, struct fuse_file_info *file_info)
 {
-    printf("FUNCTION: write. path: %s\n", path);
+//    printf("FUNCTION: write. path: %s\n", path);
 
     (void)path;
     ssize_t         retval;
@@ -530,7 +530,7 @@ int mediafirefs_write(const char *path, const char *buf, size_t size,
  */
 int mediafirefs_release(const char *path, struct fuse_file_info *file_info)
 {
-    printf("FUNCTION: release. path: %s\n", path);
+//    printf("FUNCTION: release. path: %s\n", path);
 
     (void)path;
 
@@ -589,7 +589,7 @@ int mediafirefs_release(const char *path, struct fuse_file_info *file_info)
 
 int mediafirefs_readlink(const char *path, char *buf, size_t bufsize)
 {
-    printf("FUNCTION: readlink. path: %s\n", path);
+//    printf("FUNCTION: readlink. path: %s\n", path);
 
     (void)path;
     (void)buf;
@@ -609,7 +609,7 @@ int mediafirefs_readlink(const char *path, char *buf, size_t bufsize)
 
 int mediafirefs_mknod(const char *path, mode_t mode, dev_t dev)
 {
-    printf("FUNCTION: mknod. path: %s\n", path);
+//    printf("FUNCTION: mknod. path: %s\n", path);
 
     (void)path;
     (void)mode;
@@ -629,7 +629,7 @@ int mediafirefs_mknod(const char *path, mode_t mode, dev_t dev)
 
 int mediafirefs_symlink(const char *target, const char *linkpath)
 {
-    printf("FUNCTION: symlink. target: %s, linkpath: %s\n", target, linkpath);
+//    printf("FUNCTION: symlink. target: %s, linkpath: %s\n", target, linkpath);
 
     (void)target;
     (void)linkpath;
@@ -648,7 +648,7 @@ int mediafirefs_symlink(const char *target, const char *linkpath)
 
 int mediafirefs_rename(const char *oldpath, const char *newpath)
 {
-    printf("FUNCTION: rename. oldpath: %s, newpath %s\n", oldpath, newpath);
+//    printf("FUNCTION: rename. oldpath: %s, newpath %s\n", oldpath, newpath);
 
     char           *temp1;
     char           *temp2;
@@ -748,7 +748,7 @@ int mediafirefs_rename(const char *oldpath, const char *newpath)
 
 int mediafirefs_link(const char *target, const char *linkpath)
 {
-    printf("FUNCTION: link. target: %s, linkpath %s\n", target, linkpath);
+//    printf("FUNCTION: link. target: %s, linkpath %s\n", target, linkpath);
 
     (void)target;
     (void)linkpath;
@@ -767,7 +767,7 @@ int mediafirefs_link(const char *target, const char *linkpath)
 
 int mediafirefs_chmod(const char *path, mode_t mode)
 {
-    printf("FUNCTION: chmod. path: %s\n", path);
+//    printf("FUNCTION: chmod. path: %s\n", path);
     (void)path;
     (void)mode;
     struct mediafirefs_context_private *ctx;
@@ -785,7 +785,7 @@ int mediafirefs_chmod(const char *path, mode_t mode)
 
 int mediafirefs_chown(const char *path, uid_t uid, gid_t gid)
 {
-    printf("FUNCTION: chown. path: %s\n", path);
+//    printf("FUNCTION: chown. path: %s\n", path);
 
     (void)path;
     (void)uid;
@@ -805,7 +805,7 @@ int mediafirefs_chown(const char *path, uid_t uid, gid_t gid)
 
 int mediafirefs_truncate(const char *path, off_t length)
 {
-    printf("FUNCTION: truncate. path: %s, length: %zd\n", path, length);
+//    printf("FUNCTION: truncate. path: %s, length: %zd\n", path, length);
 
     bool            is_file = 0;
     const char     *key = NULL;
@@ -863,7 +863,7 @@ int mediafirefs_truncate(const char *path, off_t length)
 
 int mediafirefs_statfs(const char *path, struct statvfs *buf)
 {
-    printf("FUNCTION: statfs. path: %s\n", path);
+//    printf("FUNCTION: statfs. path: %s\n", path);
 
     // TODO:    add mfuser to ctx and store it accross the system.
     //          instantiating it every time on a per-instance is not ideal.
@@ -929,7 +929,7 @@ int mediafirefs_statfs(const char *path, struct statvfs *buf)
 
 int mediafirefs_flush(const char *path, struct fuse_file_info *file_info)
 {
-    printf("FUNCTION: flush. path: %s\n", path);
+//    printf("FUNCTION: flush. path: %s\n", path);
 
     FILE           *fh;
     char           *file_name;
@@ -1107,7 +1107,7 @@ int mediafirefs_flush(const char *path, struct fuse_file_info *file_info)
 int mediafirefs_fsync(const char *path, int datasync,
                       struct fuse_file_info *file_info)
 {
-    printf("FUNCTION: fsync. path: %s\n", path);
+//    printf("FUNCTION: fsync. path: %s\n", path);
 
     (void)path;
     (void)datasync;
@@ -1128,7 +1128,7 @@ int mediafirefs_fsync(const char *path, int datasync,
 int mediafirefs_setxattr(const char *path, const char *name,
                          const char *value, size_t size, int flags)
 {
-    printf("FUNCTION: setxattr. path: %s\n", path);
+//    printf("FUNCTION: setxattr. path: %s\n", path);
 
     (void)path;
     (void)name;
@@ -1151,7 +1151,7 @@ int mediafirefs_setxattr(const char *path, const char *name,
 int mediafirefs_getxattr(const char *path, const char *name, char *value,
                          size_t size)
 {
-    printf("FUNCTION: getxattr. path: %s\n", path);
+//    printf("FUNCTION: getxattr. path: %s\n", path);
 
     (void)path;
     (void)name;
@@ -1172,7 +1172,7 @@ int mediafirefs_getxattr(const char *path, const char *name, char *value,
 
 int mediafirefs_listxattr(const char *path, char *list, size_t size)
 {
-    printf("FUNCTION: listxattr. path: %s\n", path);
+//    printf("FUNCTION: listxattr. path: %s\n", path);
 
     (void)path;
     (void)list;
@@ -1192,7 +1192,7 @@ int mediafirefs_listxattr(const char *path, char *list, size_t size)
 
 int mediafirefs_removexattr(const char *path, const char *list)
 {
-    printf("FUNCTION: removexattr. path: %s\n", path);
+//    printf("FUNCTION: removexattr. path: %s\n", path);
 
     (void)path;
     (void)list;
@@ -1211,7 +1211,7 @@ int mediafirefs_removexattr(const char *path, const char *list)
 
 int mediafirefs_opendir(const char *path, struct fuse_file_info *file_info)
 {
-    printf("FUNCTION: opendir. path: %s\n", path);
+//    printf("FUNCTION: opendir. path: %s\n", path);
 
     (void)path;
     (void)file_info;
@@ -1230,7 +1230,7 @@ int mediafirefs_opendir(const char *path, struct fuse_file_info *file_info)
 
 int mediafirefs_releasedir(const char *path, struct fuse_file_info *file_info)
 {
-    printf("FUNCTION: releasedir. path: %s\n", path);
+//    printf("FUNCTION: releasedir. path: %s\n", path);
 
     (void)path;
     (void)file_info;
@@ -1250,7 +1250,7 @@ int mediafirefs_releasedir(const char *path, struct fuse_file_info *file_info)
 int mediafirefs_fsyncdir(const char *path, int datasync,
                          struct fuse_file_info *file_info)
 {
-    printf("FUNCTION: fsyncdir. path: %s\n", path);
+//    printf("FUNCTION: fsyncdir. path: %s\n", path);
 
     (void)path;
     (void)datasync;
@@ -1278,7 +1278,7 @@ void* mediafirefs_init(struct fuse_conn_info *conn)
 
 int mediafirefs_access(const char *path, int mode)
 {
-    printf("FUNCTION: access. path: %s\n", path);
+//    printf("FUNCTION: access. path: %s\n", path);
 
     (void)path;
     (void)mode;
@@ -1297,7 +1297,7 @@ int mediafirefs_access(const char *path, int mode)
 
 int mediafirefs_utimens(const char *path, const struct timespec tv[2])
 {
-    printf("FUNCTION: utimens. path: %s\n", path);
+//    printf("FUNCTION: utimens. path: %s\n", path);
 
     time_t          since_epoch;
     struct tm       local_time;

--- a/fuse/operations.c
+++ b/fuse/operations.c
@@ -834,7 +834,7 @@ int mediafirefs_truncate(const char *path, off_t length)
     }
 
     retval = folder_tree_truncate_file(ctx->tree, ctx->conn, path);
-
+    
     if (retval == -1) {
 	pthread_mutex_unlock(&(ctx->mutex));
 	return -ENOENT;
@@ -963,11 +963,8 @@ int mediafirefs_flush(const char *path, struct fuse_file_info *file_info)
 
         if (retval != 0) {
             fprintf(stderr, "failed to calculate hash\n");
-//            fclose(fh);
             free(temp1);
             free(temp2);
-//            free(openfile->path);
-//            free(openfile);
             pthread_mutex_unlock(&(ctx->mutex));
             return -EACCES;
         }
@@ -978,11 +975,8 @@ int mediafirefs_flush(const char *path, struct fuse_file_info *file_info)
                                          folder_key, &check_result);
 
         if (retval != 0) {
-//            fclose(fh);
             free(temp1);
             free(temp2);
-//            free(openfile->path);
-//            free(openfile);
             free(hash);
             fprintf(stderr, "mfconn_api_upload_check failed\n");
             fprintf(stderr, "file_name: %s\n",file_name);
@@ -1000,11 +994,8 @@ int mediafirefs_flush(const char *path, struct fuse_file_info *file_info)
                                                file_name, hash, size,
                                                folder_key);
 
-//            fclose(fh);
             free(temp1);
             free(temp2);
-//            free(openfile->path);
-//            free(openfile);
             free(hash);
 
             if (retval != 0) {
@@ -1018,11 +1009,8 @@ int mediafirefs_flush(const char *path, struct fuse_file_info *file_info)
             retval = mfconn_api_upload_simple(ctx->conn, folder_key,
                                               fh, file_name, &upload_key);
 
-//            fclose(fh);
             free(temp1);
             free(temp2);
-//            free(openfile->path);
-//            free(openfile);
             free(hash);
 
             if (retval != 0 || upload_key == NULL) {
@@ -1072,19 +1060,6 @@ int mediafirefs_flush(const char *path, struct fuse_file_info *file_info)
 
     pthread_mutex_unlock(&(ctx->mutex));
 
-/*    
-    (void)path;
-    (void)file_info;
-    struct mediafirefs_context_private *ctx;
-
-    ctx = fuse_get_context()->private_data;
-
-    pthread_mutex_lock(&(ctx->mutex));
-
-    fprintf(stderr, "flush is a no-op\n");
-
-    pthread_mutex_unlock(&(ctx->mutex));
-*/
     return 0;
 }
 

--- a/fuse/operations.c
+++ b/fuse/operations.c
@@ -355,17 +355,12 @@ int mediafirefs_unlink(const char *path)
 /*
  * the following restrictions apply:
  *  1. a file can be opened in read-only mode more than once at a time
- *  2. a file can only be be opened in write-only or read-write mode if it is
- *     not open for writing at the same time
+ *  2. a file can only be be opened in write-only or read-write mode
+ *     more than once at a time.
  *  3. a file that is only local and has not been uploaded yet cannot be read
  *     from
  *  4. a file that has opened in any way will not be updated to its latest
  *     remote revision until all its opened handles are closed
- *
- *  Point 2 is enforced by a lookup in the writefiles string vector. If the
- *  path is in there then it was either just created locally or opened with
- *  write-only or read-write. In both cases it must not be opened for
- *  writing again.
  *
  *  Point 3 is enforced by the lookup in the hashtable failing.
  *
@@ -532,10 +527,6 @@ int mediafirefs_write(const char *path, const char *buf, size_t size,
 /*
  * note: the return value of release() is ignored by fuse
  *
- * also, release() is called asynchronously: the close() call will finish
- * before this function returns. Thus, the uploading should be done once flush
- * is called but this becomes tricky because mediafire doesn't like files of
- * zero length and flush() is often called right after creation.
  */
 int mediafirefs_release(const char *path, struct fuse_file_info *file_info)
 {

--- a/fuse/operations.c
+++ b/fuse/operations.c
@@ -852,7 +852,7 @@ int mediafirefs_rename(const char *oldpath, const char *newpath)
 
     if (strcmp(oldname, newname) != 0) {
         if (is_file) {
-            retval = mfconn_api_file_update(ctx->conn, key, newname, NULL);
+            retval = mfconn_api_file_update(ctx->conn, key, newname, NULL, false);
         } else {
             retval = mfconn_api_folder_update(ctx->conn, key, newname, NULL);
         }
@@ -1441,7 +1441,7 @@ int mediafirefs_utimens(const char *path, const struct timespec tv[2])
     fprintf(stderr, "utimens file set: %s\n", print_time);
 
     if (is_file) {
-        retval = mfconn_api_file_update(ctx->conn, key, NULL, print_time);
+        retval = mfconn_api_file_update(ctx->conn, key, NULL, print_time, false);
     } else {
         retval = mfconn_api_folder_update(ctx->conn, key, NULL, print_time);
     }

--- a/fuse/operations.c
+++ b/fuse/operations.c
@@ -386,9 +386,9 @@ int mediafirefs_open(const char *path, struct fuse_file_info *file_info)
      * not read-only mode and abort if yes */
     if ((file_info->flags & O_ACCMODE) != O_RDONLY
         && stringv_mem(ctx->sv_writefiles, path)) {
-        fprintf(stderr, "file %s was already opened for writing\n", path);
-        pthread_mutex_unlock(&(ctx->mutex));
-        return -EACCES;
+//        fprintf(stderr, "file %s was already opened for writing\n", path);
+//        pthread_mutex_unlock(&(ctx->mutex));
+//        return -EACCES;
     }
 
     is_open = false;
@@ -405,7 +405,7 @@ int mediafirefs_open(const char *path, struct fuse_file_info *file_info)
         && stringv_mem(ctx->sv_writefiles, path)) {
         is_open = true;
     }
-
+    is_open = false;
     fd = folder_tree_open_file(ctx->tree, ctx->conn, path, file_info->flags,
                                !is_open);
     if (fd < 0) {
@@ -462,7 +462,7 @@ int mediafirefs_create(const char *path, mode_t mode,
         pthread_mutex_unlock(&(ctx->mutex));
         return -EACCES;
     }
-
+    
     openfile = malloc(sizeof(struct mediafirefs_openfile));
     openfile->fd = fd;
     openfile->is_local = true;
@@ -474,6 +474,9 @@ int mediafirefs_create(const char *path, mode_t mode,
     stringv_add(ctx->sv_writefiles, path);
 
     pthread_mutex_unlock(&(ctx->mutex));
+
+    mediafirefs_flush(path, file_info);
+//    openfile->is_local = false;
 
     return 0;
 }
@@ -568,13 +571,14 @@ int mediafirefs_release(const char *path, struct fuse_file_info *file_info)
                 openfile->path);
         exit(1);
     }
+/*
     if (stringv_mem(ctx->sv_writefiles, openfile->path) != 0) {
         fprintf(stderr,
                 "FATAL: writefiles entry %s was found more than once\n",
                 openfile->path);
         exit(1);
     }
-
+*/
     close(openfile->fd);
 
     free(openfile->path);

--- a/mfapi/apicalls.h
+++ b/mfapi/apicalls.h
@@ -94,7 +94,7 @@ int             mfconn_api_file_move(mfconn * conn, const char *quickkey,
 
 int             mfconn_api_file_update(mfconn * conn, const char *quickkey,
                                        const char *filename,
-                                       const char *mtime);
+                                       const char *mtime, bool truncate);
 
 int             mfconn_api_folder_create(mfconn * conn, const char *parent,
                                          const char *name);

--- a/mfapi/apicalls.h
+++ b/mfapi/apicalls.h
@@ -35,7 +35,7 @@
 #define MFAPI_MAX_LEN_KEY 15
 #define MFAPI_MAX_LEN_NAME 255
 
-#define MFAPI_VERSION "1.2"
+#define MFAPI_VERSION "1.4"
 
 enum mfconn_device_change_type {
     MFCONN_DEVICE_CHANGE_DELETED_FOLDER,

--- a/mfapi/apicalls.h
+++ b/mfapi/apicalls.h
@@ -162,6 +162,7 @@ int             mfconn_api_upload_instant(mfconn * conn, const char *quick_key,
 
 int             mfconn_api_upload_simple(mfconn * conn, const char *folderkey,
                                          FILE * fh, const char *file_name,
+					 bool replace,
                                          char **upload_key);
 
 int             mfconn_api_upload_patch(mfconn * conn, const char *quickkey,

--- a/mfapi/apicalls/file_update.c
+++ b/mfapi/apicalls/file_update.c
@@ -26,7 +26,7 @@
 #include "../apicalls.h"        // IWYU pragma: keep
 
 int mfconn_api_file_update(mfconn * conn, const char *quickkey,
-                           const char *filename, const char *mtime)
+                           const char *filename, const char *mtime, bool truncate)
 {
     const char     *api_call;
     int             retval;
@@ -43,7 +43,7 @@ int mfconn_api_file_update(mfconn * conn, const char *quickkey,
     if (strlen(quickkey) != 15)
         return -1;
 
-    if (filename == NULL && mtime == NULL)
+    if (filename == NULL && mtime == NULL && truncate == false)
         return -1;
 
     if (filename != NULL) {
@@ -86,6 +86,15 @@ int mfconn_api_file_update(mfconn * conn, const char *quickkey,
                                                 "&response_format=json",
                                                 quickkey, filename_urlenc);
         }
+
+	if (truncate) {
+            api_call = mfconn_create_signed_get(conn, 0, "file/update.php",
+                                                "?quick_key=%s"
+						"&truncate=%s"
+                                                "&response_format=json",
+                                                quickkey,
+						"yes");
+	}
 
         if (filename_urlenc != NULL)
             free(filename_urlenc);

--- a/mfapi/apicalls/upload_check.c
+++ b/mfapi/apicalls/upload_check.c
@@ -66,8 +66,8 @@ int mfconn_api_upload_check(mfconn * conn, const char *filename,
             return -1;
         }
 
-        if(size != 0) {
-
+        if(size != 0 || 1) {
+	    /* will always execute */
             api_call = mfconn_create_signed_get(conn, 0,
                                                 "upload/check.php",
                                                 "?response_format=json"
@@ -78,7 +78,7 @@ int mfconn_api_upload_check(mfconn * conn, const char *filename,
                                                 filename_urlenc,
                                                 size, hash, folder_key);
         } else {
-
+	    /* will not execute */
             api_call = mfconn_create_signed_get(conn, 0,
                                                 "upload/check.php",
                                                 "?response_format=json"

--- a/mfapi/apicalls/upload_simple.c
+++ b/mfapi/apicalls/upload_simple.c
@@ -38,7 +38,8 @@ static int      _decode_upload_simple(mfhttp * conn, void *data);
 
 int
 mfconn_api_upload_simple(mfconn * conn, const char *folderkey,
-                         FILE * fh, const char *file_name, char **upload_key)
+                         FILE * fh, const char *file_name, bool replace,
+			 char **upload_key)
 {
     const char     *api_call;
     int             retval;
@@ -86,10 +87,18 @@ mfconn_api_upload_simple(mfconn * conn, const char *folderkey,
                                                 "upload/simple.php",
                                                 "?response_format=json");
         } else {
-            api_call = mfconn_create_signed_get(conn, 0,
-                                                "upload/simple.php",
-                                                "?response_format=json"
-                                                "&folder_key=%s", folderkey);
+	    if (replace) {
+		api_call = mfconn_create_signed_get(conn, 0,
+						    "upload/simple.php",
+						    "?response_format=json"
+						    "&action_on_duplicate=replace"
+						    "&folder_key=%s", folderkey);
+	    } else {
+		api_call = mfconn_create_signed_get(conn, 0,
+						    "upload/simple.php",
+						    "?response_format=json"
+						    "&folder_key=%s", folderkey);
+	    }
         }
         if (api_call == NULL) {
             fprintf(stderr, "mfconn_create_signed_get failed\n");

--- a/mfshell/commands/put.c
+++ b/mfshell/commands/put.c
@@ -69,7 +69,7 @@ int mfshell_cmd_put(mfshell * mfshell, int argc, char *const argv[])
 
     retval = mfconn_api_upload_simple(mfshell->conn,
                                       folder_get_key(mfshell->folder_curr),
-                                      fh, file_name, &upload_key);
+                                      fh, file_name, false, &upload_key);
 
     fclose(fh);
     free(temp);

--- a/utils/fsio.c
+++ b/utils/fsio.c
@@ -135,7 +135,7 @@ fsio_file_read(fsio_t *fsio,ssize_t *bytes)
     // zero out our counters
     _fsio_reset_counters(fsio);
 
-    while(fsio->bytes_read < (size_t)*bytes)
+    while(fsio->bytes_read <= (size_t)*bytes)
     {
         bytes_read = _fsio_read_block(fsio);
 

--- a/utils/fsio.c
+++ b/utils/fsio.c
@@ -209,16 +209,19 @@ fsio_file_copy(fsio_t *fsio,ssize_t *bytes)
 
         // were done
         if(bytes_read == 0) break;
-
+	fsio->data_sz = bytes_read;
         bytes_written = _fsio_write_blocks(fsio);
 
         if(bytes_written != bytes_read) break;
+
 
         bytes_total += bytes_written;
     }
 
     if(bytes_total < *bytes)
     {
+	fprintf(stderr, "ERROR: bytes read: %zd, bytes written: %zd\n",
+		bytes_read, bytes_written);
         *bytes = bytes_total;
         return -1;
     }

--- a/utils/hash.c
+++ b/utils/hash.c
@@ -177,6 +177,10 @@ int calc_sha256(FILE * file, unsigned char *hash, uint64_t * size)
 
     retval = fsio_file_read(fsio,&bytes);
 
+    if (size && *size == (uint64_t) -1) {
+	    *size = bytes;
+    }
+
     fsio_destroy(fsio,true);
     if(hasher != NULL) free(hasher);
 


### PR DESCRIPTION
Move uploading code from "release" to "flush. Now "release" is responsible for only freeing resources.
"truncate" is implemented.
You can now create zero byte files. 