### PR TITLE
Remove deprecated readdir_r function

### DIFF
--- a/fuse/hashtbl.c
+++ b/fuse/hashtbl.c
@@ -1891,8 +1891,9 @@ void folder_tree_cleanup_filecache(folder_tree * tree, uint64_t allowed_size)
 
     for (;;) {
         endp = NULL;
-        retval = readdir_r(dirp, entryp, &endp);
-        if (retval != 0) {
+        errorno = 0;
+        endp = readdir(dirp);
+        if (!endp && errorno) {
             fprintf(stderr, "readdir_r failed\n");
             free(entryp);
             closedir(dirp);


### PR DESCRIPTION
Replaces readdir_r with readdir as per https://github.com/MediaFire/mediafire-fuse/issues/59 and https://github.com/MediaFire/mediafire-fuse/issues/60, specifically using fix from @iordain at https://github.com/MediaFire/mediafire-fuse/issues/59#issuecomment-291226279